### PR TITLE
Phase 1: Decompose and clean up for affine gap support

### DIFF
--- a/src/pairwise/linear.cljc
+++ b/src/pairwise/linear.cljc
@@ -65,34 +65,35 @@
      }))
 
 
+(defn- select-best-scores
+  "Given candidate score maps, return the max score and all tied sources.
+   For local alignment, normalizes zero-score candidates to {:score 0 :from nil}."
+  [candidates type]
+  (let [valid     (filter has-score? (remove nil? candidates))
+        max-score (:score (apply max-key :score valid))
+        with-zero (if (= type :local)
+                    (map #(if (zero? (:score %)) {:score 0 :from nil} %) valid)
+                    valid)
+        sources   (distinct (filter #(= (:score %) max-score) with-zero))]
+    {:max-score max-score
+     :sources   sources}))
+
 (defn score-cell
   "score a cell"
   [D S gap-penalty s1 s2 row col & {:keys [type]}]
-  (let [L1        (get (vec (seq s1)) (dec col)) 
-        L2        (get (vec (seq s2)) (dec row))
-        cols      (inc (count s1))
-        step      (+ col (* row cols))
-        s         (get S [L1 L2])
-        score-vec (remove nil?
-                          [(substitution-score D row col s)
-                           (score-horizontal-gap D row col gap-penalty)
-                           (score-vertical-gap D row col gap-penalty)
-                           (when (= type :local) {:score 0 :from nil})])
-        score-vec (filter has-score? score-vec)
-        max-score (:score (apply max-key :score score-vec))
-        score-vec (if (= type :local)
-                    (map #(if (zero? (:score %1)) {:score 0 :from nil} %1) score-vec)
-                    score-vec)
-        score-vec (distinct (filter #(= (:score %1) max-score) score-vec))
-        direction (map :direction score-vec)
-        diag? (some #(= :diag %) direction)
-        ]
-    (assoc-in D [row col ] {:score max-score
-                            :substitution-type (if diag? (substitution-type s1 s2 col row) nil)
-                            :from  (map :from score-vec)
-                            :direction direction
-                            :step step
-                            })))
+  (let [s          (get S [(get s1 (dec col)) (get s2 (dec row))])
+        candidates [(substitution-score D row col s)
+                    (score-horizontal-gap D row col gap-penalty)
+                    (score-vertical-gap D row col gap-penalty)
+                    (when (= type :local) {:score 0 :from nil})]
+        {:keys [max-score sources]} (select-best-scores candidates type)
+        directions (map :direction sources)]
+    (assoc-in D [row col]
+              {:score             max-score
+               :substitution-type (when (some #{:diag} directions)
+                                    (substitution-type s1 s2 col row))
+               :from              (map :from sources)
+               :direction         directions})))
 
 
 (defn build-dp-matrix 
@@ -123,7 +124,7 @@
                     (keys (filter  #(zero? (:score (second %))) (graph-of D)))
                     (= type :semiglobal)
                     (filter #(or (zero? (first %)) (zero? (second %))) (keys (graph-of D)))))]
-    #(contains? goal %1)))
+    #(contains? goal %)))
 
 
 (defn alignment-score 
@@ -131,13 +132,13 @@
   [D type]
   (cond (= type :global) (get-in D [(dec (count D))
                                     (dec (count (first D))) :score])
-        (= type :local) (apply max (flatten (map #(map :score %1) D)))))
+        (= type :local) (apply max (flatten (map #(map :score %) D)))))
 
 
 (defn get-starting [D type]
   (cond (= type :global) (list [(dec (count D))
                                 (dec (count (first D)))])
-        (= type :local)  (let [top-score (apply max (flatten (map #(map :score %1) D)))
+        (= type :local)  (let [top-score (apply max (flatten (map #(map :score %) D)))
                                starting  (for [r (range (count D))
                                                c (range (count (first D)))]
                                            (when (= top-score (get-in D [r c :score]))
@@ -163,11 +164,10 @@
         start-cells (get-starting D type)
         graph       (graph-of D)
         search      (dfs graph met-goal?)
-        start-cell (first start-cells)
-        all-paths (mapcat  #(search [%1] #{%1}) start-cells)
+        all-paths (mapcat #(search [%1] #{%1}) start-cells)
         internal-cells (set (apply concat (map rest all-paths)))
         ]
-    (filter #((complement contains?) internal-cells (first %)) all-paths)))
+    (remove #(contains? internal-cells (first %)) all-paths)))
 
 
 (defn path-to-alignment

--- a/src/pairwise/matrix.cljc
+++ b/src/pairwise/matrix.cljc
@@ -1,0 +1,20 @@
+(ns pairwise.matrix)
+
+(defn matrix-dimensions
+  "Returns [rows cols] dimensions of a DP matrix."
+  [dp-matrix]
+  [(count dp-matrix) (count (first dp-matrix))])
+
+(defn cell-coordinates
+  "Returns sequence of [row col] pairs for all cells in a DP matrix."
+  [dp-matrix]
+  (let [[rows cols] (matrix-dimensions dp-matrix)]
+    (for [c (range cols) r (range rows)] [r c])))
+
+(defn direction-between
+  "Returns the direction (:diag, :horiz, :vert) between two [r c] coordinates."
+  [[r1 c1] [r2 c2]]
+  (cond
+    (= r1 r2) :horiz
+    (= c1 c2) :vert
+    :else      :diag))

--- a/src/pairwise/tikz_view.clj
+++ b/src/pairwise/tikz_view.clj
@@ -1,7 +1,7 @@
 (ns pairwise.tikz-view
   (:require [pairwise.linear :as pairwise]
+            [pairwise.matrix :as matrix]
             [pairwise.substitution :refer :all]
-            [clojure.walk :as w]
             [clojure.string :as str]
             [clojure.java.io :as io]))
 
@@ -13,19 +13,14 @@
 
 (def header (load-header))
 
-(defn- scores [D]
-  (w/prewalk #(:score %1) D))
-
 (defn scale-tikz [s1 s2]
-  (let [scale  (+ 2 (max (count s1) (count  s2)))]
-    scale
+  (let [scale (+ 2 (max (count s1) (count s2)))]
     (format "\\pgftransformscale{%3.2f}\n" (/ 8. scale))))
 
 (defn draw-grid [s1 s2]
   (let [M (inc (count s1))
         N (inc (count s2))]
     ["\\pgftransformrotate{-90}\n"
-;;     (format "\\path [use as bounding box] (-1.5,-1) rectangle (%d,%d);\n" (inc N) (inc M))
      (format "\\draw [xshift=-0.5cm,yshift=-0.5cm,color=lightgray] (0,0) grid (%d,%d);\n" N M)
      (map str (map-indexed #(format "\\draw (-1,%s) node [scale=1] {%s};\n" (inc %1) %2) (seq s1)))
      (map str (map-indexed #(format "\\draw (%s,-1) node [scale=1] {%s};\n" (inc %1) %2) (seq s2)))]
@@ -41,21 +36,26 @@
 (defn latex-command [cmd args s]
   (vector (if args
             (format "\\%s%s{\n" (name cmd) args)
-            (format "}" (name cmd))) 
+            (format "\\%s{\n" (name cmd)))
           s
           "}"))
 
 
+(defn- cell-step
+  "Compute Beamer overlay step number for a cell at [row col] in matrix D."
+  [D [row col]]
+  (inc (+ col (* row (count (first D))))))
+
 (defn- draw-score [D ij]
   (let [score (:score (get-in D ij))
-        step (inc (:step (get-in D ij)))
+        step (cell-step D ij)
         i (first ij)
         j (second ij)]
     (format "\\visible<%d->{\\draw (%d,%d) node [fill=white,scale=0.5] {%s};}\n" step i j score)))
 
 (defn- draw-dp-arrows [D ij]
   (let [from (:from (get-in D ij))
-        step (inc (:step (get-in D ij)))
+        step (cell-step D ij)
         direction (:direction (get-in D ij))
         direction-map {:horiz "drawleft"
                   :vert  "drawup"
@@ -70,15 +70,12 @@
   (let [paths    (:optimal-paths a)
         path-steps  (mapcat (partial partition 2 1) paths)
         reveal-times (flatten (:optimal-path-steps a))
+        direction-map {:horiz "drawleft" :vert "drawup" :diag "drawmatch"}
         draw-one (fn [step step-time]
                    (let [from (first step)
                          to (second step)
                          substitution-type (get-in a [:dp-matrix (first from) (second from) :substitution-type])
-                         draw (cond
-                                        (= (first from) (first to))   "drawleft"
-                                        (= (second from) (second to)) "drawup"
-                                        :else                         "drawmatch"
-                                        )]
+                         draw (direction-map (matrix/direction-between from to))]
                      (if (= substitution-type :match)
                        (format "\\visible<%d->{\\%s{%d}{%d}{optimal step}}\n" step-time draw (first from) (second from))                       
                        (format "\\visible<%d->{\\%s{%d}{%d}{optimal-but-non-identical step}}\n" step-time draw (first from) (second from))                       
@@ -91,9 +88,7 @@
 (defn tikz-alignment
   "doc-string"
   [alignments]
-  (let [ij      (for [cols (range (count (first (:dp-matrix alignments))))
-                      rows (range (count (:dp-matrix alignments)))]
-                  [rows cols])
+  (let [ij      (matrix/cell-coordinates (:dp-matrix alignments))
         content (flatten  [(draw-grid (:sequence-1 alignments) (:sequence-2 alignments))
                            (map #(draw-score (:dp-matrix alignments) %1) ij)
                            (map #(draw-dp-arrows (:dp-matrix alignments) %1) ij)
@@ -103,7 +98,6 @@
 
     (str/join   (flatten (list header  (->> (flatten content)
                                             (latex-env :tikzpicture)
-;;                                            (latex-command :resizebox "{!}{6in}")
                                             (latex-env :standaloneframe)
                                             (latex-env :document))))
               )))

--- a/src/pairwise/webapp.cljs
+++ b/src/pairwise/webapp.cljs
@@ -3,6 +3,7 @@
             [reagent.core :as reagent :refer (atom)]
             [reagent.dom :as rdom]
             [pairwise.linear :as linear]
+            [pairwise.matrix :as matrix]
             [pairwise.substitution :as sub]
             [pairwise.cljsmacros  :refer-macros [read-file]]))
 
@@ -24,6 +25,9 @@
 
 (defonce app-item-id (atom 0))
 
+(def cell-size 50)
+(def half-cell (/ cell-size 2))
+
 (defn app-results [app-state]
   (let [scoring-matrix (condp = (:scoring-matrix-type app-state)
                          :simple (sub/simple-substitution-matrix
@@ -38,55 +42,48 @@
                          :type (:alignment-type app-state))))
 
 (defn draw-arrow [app-state [r c] & {:keys [stroke stroke-width] :or {stroke "gray" stroke-width 2}}]
-  (let [x1 (+ 25 (* c 50))
-        y1 (+ 25 (* r 50))
-        from-seq (get-in app-state [:result :dp-matrix  r c :from])
-        xpos (fn [[_ c]] (+ 25 (* 50 c)))
-        ypos (fn [[r _]] (+ 25 (* 50 r)))
-        ]
-    (map  #(when-not (nil? %1)
-             [:line { :stroke stroke :stroke-width stroke-width :x1 x1 :x2 (xpos %1) :y1 y1
-                      :y2 (ypos %1)}])  from-seq)))
+  (let [x1 (+ half-cell (* c cell-size))
+        y1 (+ half-cell (* r cell-size))
+        from-seq (get-in app-state [:result :dp-matrix r c :from])
+        xpos (fn [[_ c]] (+ half-cell (* cell-size c)))
+        ypos (fn [[r _]] (+ half-cell (* cell-size r)))]
+    (map #(when-not (nil? %)
+            [:line {:stroke stroke :stroke-width stroke-width :x1 x1 :x2 (xpos %) :y1 y1
+                    :y2 (ypos %)}]) from-seq)))
 
 (defn draw-mask [_app-state [r c]]
-  (let [x1 (+ 25 (* c 50))
-        y1 (+ 25 (* r 50))]
+  (let [x1 (+ half-cell (* c cell-size))
+        y1 (+ half-cell (* r cell-size))]
     [:circle {:cx x1 :cy y1 :r 12 :fill "white"}]))
 
 (defn draw-cell [app-state [r c]]
-  (let [x (* c 50)
-        y (* r 50)
-        score (get-in app-state [:result :dp-matrix  r c :score])]
+  (let [x (* c cell-size)
+        y (* r cell-size)
+        score (get-in app-state [:result :dp-matrix r c :score])]
     [:g
-     [:rect {:x x :y y :width 50 :height 50 :fill "none" :stroke "gray" :stroke-width 0.2}]
-     [:text {:x (+ x  25) :y (+ y 25) :text-anchor "middle" :alignment-baseline "middle" :font-family "Verdana" :font-size "70%" :stroke "black"} score]
-     ]
-    ))
+     [:rect {:x x :y y :width cell-size :height cell-size :fill "none" :stroke "gray" :stroke-width 0.2}]
+     [:text {:x (+ x half-cell) :y (+ y half-cell) :text-anchor "middle" :alignment-baseline "middle" :font-family "Verdana" :font-size "70%" :stroke "black"} score]]))
 
 (defn draw-top-seq [app-state]
-  (let [draw-a-letter (fn [i x]  [:text {:x (+ 25 (* (inc i) 50)) :y -25 :font-size "150%" :text-anchor "middle" :alignment-baseline "middle"} x])]
+  (let [draw-a-letter (fn [i x] [:text {:x (+ half-cell (* (inc i) cell-size)) :y (- half-cell) :font-size "150%" :text-anchor "middle" :alignment-baseline "middle"} x])]
     (map-indexed draw-a-letter (seq (:top-seq app-state)))))
 
 (defn draw-left-seq [app-state]
   (let [draw-a-letter (fn [i x]
-                        [:text {:y (+ 25 (* (inc i) 50)) :x -25 :font-size "150%" :text-anchor "middle" :alignment-baseline "middle"} x])]
+                        [:text {:y (+ half-cell (* (inc i) cell-size)) :x (- half-cell) :font-size "150%" :text-anchor "middle" :alignment-baseline "middle"} x])]
     (map-indexed draw-a-letter (seq (:bottom-seq app-state)))))
 
 (defn svg-component [ app-state & _args ]
-  (let [ij      (for [cols (range (count (get-in app-state [:result :dp-matrix 0])))
-                      rows (range (count (get-in app-state [:result :dp-matrix])))]
-                  [rows cols])
-        cols (count (get-in app-state [:result :dp-matrix 0]))
-        rows (count (get-in app-state [:result :dp-matrix]))
-        draw-opt (fn [paths] (map #(draw-arrow app-state %1 :stroke "red" :stroke-width 4) paths))
-        ]
-      [:svg {:width   "80%"; (str (* cols 50)) 
-             :height  "50%";(str (* rows 50))
-             :viewBox (print-str -50 -50 (str (* (inc  cols) 50)) (str (* (inc  rows) 50)))
+  (let [dp-matrix (get-in app-state [:result :dp-matrix])
+        ij        (matrix/cell-coordinates dp-matrix)
+        [rows cols] (matrix/matrix-dimensions dp-matrix)
+        draw-opt (fn [paths] (map #(draw-arrow app-state % :stroke "red" :stroke-width 4) paths))]
+      [:svg {:width   "80%"
+             :height  "50%"
+             :viewBox (print-str (- cell-size) (- cell-size) (str (* (inc cols) cell-size)) (str (* (inc rows) cell-size)))
          :id    "canvas"
-         :style {;:outline          "1px solid black"
-                 :background-color "#fff"}}
-       [:rect {:x 0 :y 0 :width (* 50 cols) :height (*  50 rows) :fill "none" :stroke "black" :stroke-width 1}]
+         :style {:background-color "#fff"}}
+       [:rect {:x 0 :y 0 :width (* cell-size cols) :height (* cell-size rows) :fill "none" :stroke "black" :stroke-width 1}]
        (map (partial draw-arrow app-state) ij)
        (map draw-opt (:optimal-paths (:result app-state)))
        (map (partial draw-mask app-state) ij)


### PR DESCRIPTION
## Summary
- **Fix tikz_view bugs**: `latex-command` producing `}` instead of `\command{`; dead code removal
- **Decompose `score-cell`**: Extract `select-best-scores` function, reducing cyclomatic complexity from ~12 to ~4
- **Separate concerns**: Move `:step` (Beamer overlay timing) from algorithm layer to tikz_view presentation layer
- **Extract `pairwise.matrix`**: Shared `.cljc` namespace with `matrix-dimensions`, `cell-coordinates`, `direction-between` — used by both tikz_view and webapp
- **Webapp cleanup**: Named constants (`cell-size`, `half-cell`) replace magic numbers; idiomatic `%` in single-arg fns
- **Idiomatic Clojure**: `(complement contains?)` → `remove`, unused bindings removed

## Test plan
- [x] All 29 tests (112 assertions) pass
- [x] `npm run dev` — webapp renders correctly at localhost:3000
- [ ] `pairwise -1 HEAGAWGHEE -2 PAWHEAE -m BLOSUM50 -g 8` — CLI works
- [ ] `pairwise -1 ACGT -2 ACGT -o test.tex` — TikZ output valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)